### PR TITLE
bugfix: get_resources should be a GET request.

### DIFF
--- a/cacpy/CACPy.py
+++ b/cacpy/CACPy.py
@@ -253,4 +253,4 @@ class CACPy:
         """
 
         return self._make_request(RESOURCE_URL,
-                                  type="POST")
+                                  type="GET")


### PR DESCRIPTION
If sent as a POST request it returns an API key not found error.
